### PR TITLE
change name of Geo class to Relatable

### DIFF
--- a/src/Data/Geometry/Geos/Geometry.hs
+++ b/src/Data/Geometry/Geos/Geometry.hs
@@ -80,7 +80,7 @@ binaryPredicate_ :: (R.GeomConst -> R.GeomConst -> Geos Bool)
                   -> Bool
 binaryPredicate_ f g1 g2 = runGeos . join $ (f <$> convertGeometryToRaw g1 <*> convertGeometryToRaw g2)
 
-instance Geo (Geometry a) where
+instance Relatable (Geometry a) where
   disjoint = binaryPredicate_ R.disjoint
   touches = binaryPredicate_ R.touches
   intersects = binaryPredicate_ R.intersects

--- a/src/Data/Geometry/Geos/Prepared.hs
+++ b/src/Data/Geometry/Geos/Prepared.hs
@@ -41,7 +41,7 @@ queryPrepared :: (RP.PreparedGeometry -> RG.GeomConst -> Geos Bool)
               -> Bool 
 queryPrepared f pg g = runGeos $ G.convertGeometryToRaw g >>= (f pg)
 
-instance Geo (RP.PreparedGeometry) where
+instance Relatable (RP.PreparedGeometry) where
   contains = queryPrepared RP.contains
   coveredBy = queryPrepared RP.coveredBy 
   covers = queryPrepared RP.covers 

--- a/src/Data/Geometry/Geos/Types.hs
+++ b/src/Data/Geometry/Geos/Types.hs
@@ -5,7 +5,7 @@ import qualified Data.Vector as V
 import Data.Monoid
 import Data.Data
 
-class Geo a where
+class Relatable a where
   contains ::  a -> Geometry b -> Bool
   coveredBy :: a -> Geometry b -> Bool
   covers :: a -> Geometry b -> Bool


### PR DESCRIPTION
The idea here is
1) There are too many classes/types that start with Geo*. Separate this one out to lend clarity.
2) "Relate" is the underlying set of functions used in the actual Geos api. This mimics that.