### PR TITLE
Example of failing test when doing round trip parse/writing hex

### DIFF
--- a/src/Data/Geometry/Geos/Raw/Internal.hsc
+++ b/src/Data/Geometry/Geos/Raw/Internal.hsc
@@ -16,7 +16,7 @@ newtype GEOSGeomType = GEOSGeomType { unGEOSGeomType :: CInt }
   , lineStringId = GEOS_LINESTRING
   , polygonId = GEOS_POLYGON
   , multiPointId = GEOS_MULTIPOINT
-  , multiLineStringId = GEOS_MULTIPOINT
+  , multiLineStringId = GEOS_MULTILINESTRING
   , multiPolygonId = GEOS_MULTIPOLYGON
   , geometryCollectionId = GEOS_GEOMETRYCOLLECTION
 }
@@ -24,9 +24,9 @@ newtype GEOSGeomType = GEOSGeomType { unGEOSGeomType :: CInt }
 newtype GEOSByteOrder = GEOSByteOrder { unGEOSByteOrder :: CInt}
   deriving (Eq, Show)
 
-#{ enum GEOSByteOrder, GEOSByteOrder, 
+#{ enum GEOSByteOrder, GEOSByteOrder,
     bigEndian = 0
-  , littleEndian = 1 
+  , littleEndian = 1
 }
 
 data GEOSContextHandle_HS
@@ -47,152 +47,152 @@ data GEOSWKTWriter
 data GEOSWKTReader
 
 
-foreign import ccall  
+foreign import ccall
   "notice_handlers.h init_GEOS"
    geos_init :: IO GEOSContextHandle_t
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &finishGEOS_r"
   geos_finish :: FunPtr (GEOSContextHandle_t -> IO ())
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSContext_setNoticeHandler_r"
   geos_setNoticeHandler :: GEOSContextHandle_t -> GEOSMessageHandler -> IO GEOSMessageHandler
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSContext_setErrorHandler_r"
   geos_setErrorHandler :: GEOSContextHandle_t -> GEOSMessageHandler -> IO GEOSMessageHandler
 
 -- Info
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetSRID_r"
   geos_GetSRID :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt
 
-foreign import ccall 
+foreign import ccall
 
   "geos_c.h GEOSSetSRID_r"
   geos_SetSRID :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CInt -> IO ()
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_getCoordSeq_r"
   geos_GetCoordSeq :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSCoordSequence)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeomTypeId_r"
   geos_GeomTypeId :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeomType_r"
   geos_GeomType :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr CChar)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSNormalize_r"
   geos_Normalize :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt
 
   -- polygons
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetInteriorRingN_r"
   geos_GetInteriorRingN :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CInt -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetExteriorRing_r"
   geos_GetExteriorRing :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetNumInteriorRings_r"
-  geos_GetNumInteriorRings :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt 
+  geos_GetNumInteriorRings :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt
 -- multigeometries
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetNumGeometries_r"
-  geos_GetNumGeometries :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt 
+  geos_GetNumGeometries :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetGeometryN_r"
-  geos_GetGeometryN :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CInt -> IO (Ptr GEOSGeometry) 
+  geos_GetGeometryN :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CInt -> IO (Ptr GEOSGeometry)
 
-  
+
 -- Linear Referencing
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSProject_r"
   geos_Project :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CDouble
---- 
-foreign import ccall 
+---
+foreign import ccall
   "geos_c.h GEOSInterpolate_r"
   geos_Interpolate :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CDouble -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSProjectNormalized_r"
   geos_ProjectNormalized :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CDouble
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSInterpolateNormalized_r"
   geos_InterpolateNormalized :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CDouble -> IO (Ptr GEOSGeometry)
 
  -- Coord Sequence  -- return 0 on exception
  --
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_create_r"
-  geos_CoordSeqCreate :: GEOSContextHandle_t -> CUInt -> CUInt -> IO (Ptr GEOSCoordSequence)  
+  geos_CoordSeqCreate :: GEOSContextHandle_t -> CUInt -> CUInt -> IO (Ptr GEOSCoordSequence)
 
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_clone_r"
   geos_CoordSeqClone :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> IO (Ptr GEOSCoordSequence )
 
-foreign import ccall 
-  "geos_c.h &GEOSCoordSeq_destroy_r" 
+foreign import ccall
+  "geos_c.h &GEOSCoordSeq_destroy_r"
   geos_CoordSeqDestroy :: FunPtr (GEOSContextHandle_t -> Ptr GEOSCoordSequence -> IO ())
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_setX_r"
-  geos_CoordSeqSetX :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CDouble -> IO CInt 
+  geos_CoordSeqSetX :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_setY_r"
-  geos_CoordSeqSetY :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CDouble -> IO CInt 
+  geos_CoordSeqSetY :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_setZ_r"
-  geos_CoordSeqSetZ :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CDouble -> IO CInt 
+  geos_CoordSeqSetZ :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_setOrdinate_r"
   geos_CoordSeqSetOrdinate :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CUInt -> CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_getX_r"
   geos_CoordSeqGetX :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> Ptr CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_getY_r"
   geos_CoordSeqGetY :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> Ptr CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_getZ_r"
   geos_CoordSeqGetZ :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> Ptr CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_getOrdinate_r"
   geos_CoordSeqGetOrdinate :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> CUInt -> CUInt -> Ptr CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_getSize_r"
   geos_CoordSeqGetSize :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> Ptr CUInt -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetNumCoordinates_r"
   geos_GetNumCoordinates :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoordSeq_getDimensions_r"
   geos_CoordSeqGetDimensions :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> Ptr CUInt -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &GEOSGeom_destroy_r"
   geos_GeomDestroy :: FunPtr (GEOSContextHandle_t -> Ptr GEOSGeometry -> IO ())
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_clone_r"
   geos_GeomClone :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
@@ -200,23 +200,23 @@ foreign import ccall
 -- * GEOSCoordSequence* arguments will become ownership of the returned object.
 -- * All functions return NULL on exception.
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createPoint_r"
   geos_GeomCreatePoint :: GEOSContextHandle_t -> Ptr GEOSCoordSequence -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createEmptyPoint_r"
   geos_GeomCreateEmptyPoint :: GEOSContextHandle_t -> IO (Ptr GEOSGeometry)
-  
-foreign import ccall 
+
+foreign import ccall
   "geos_c.h GEOSGeom_createLinearRing_r"
   geos_GeomCreateLinearRing ::  GEOSContextHandle_t -> Ptr GEOSCoordSequence -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createLineString_r"
   geos_GeomCreateLineString ::  GEOSContextHandle_t -> Ptr GEOSCoordSequence -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createEmptyLineString_r"
   geos_GeomCreateEmptyLineString :: GEOSContextHandle_t -> IO (Ptr GEOSGeometry)
 
@@ -224,20 +224,20 @@ foreign import ccall
 --The caller remains owner of the array, but pointed-to
 --objects become ownership of the returned GEOSGeometry.
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createEmptyPolygon_r"
   geos_GeomCreateEmptyPolygon :: GEOSContextHandle_t -> IO (Ptr GEOSGeometry)
 
   -- todo: this might not work as a plain pointer
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createPolygon_r"
   geos_GeomCreatePolygon :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr (Ptr GEOSGeometry) -> CUInt -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createCollection_r"
   geos_GeomCreateCollection :: GEOSContextHandle_t -> CInt -> Ptr (Ptr GEOSGeometry) -> CUInt -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGeom_createEmptyCollection_r"
   geos_GeomCreateEmptyCollection :: GEOSContextHandle_t -> CInt -> IO (Ptr GEOSGeometry)
 
@@ -249,7 +249,7 @@ newtype BufferCapStyle = BufferCapStyle { unBufferCapStyle :: CInt }
     deriving (Eq,Show)
 
 #{ enum BufferCapStyle, BufferCapStyle,
-    capRound = 1 
+    capRound = 1
   , capFlat = 2
   , capSquare = 3
 }
@@ -262,105 +262,105 @@ newtype BufferJoinStyle = BufferJoinStyle { unBufferJoinStyle :: CInt }
   , joinMitre = 2
   , joinBevel = 3
 }
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBuffer_r"
-  geos_Buffer :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CDouble -> CInt -> IO (Ptr GEOSGeometry) 
+  geos_Buffer :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CDouble -> CInt -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferParams_create_r"
-  geos_BufferParamsCreate :: GEOSContextHandle_t -> IO (Ptr GEOSBufferParams) 
+  geos_BufferParamsCreate :: GEOSContextHandle_t -> IO (Ptr GEOSBufferParams)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &GEOSBufferParams_destroy_r"
   geos_BufferParamsDestroy :: FunPtr (GEOSContextHandle_t -> Ptr GEOSBufferParams -> IO ())
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferParams_setEndCapStyle_r"
-  geos_BufferParamsSetEndCapStyle :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CInt -> IO CInt 
+  geos_BufferParamsSetEndCapStyle :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CInt -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferParams_setJoinStyle_r"
-  geos_BufferParamsSetJoinStyle :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CInt -> IO CInt 
+  geos_BufferParamsSetJoinStyle :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CInt -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferParams_setMitreLimit_r"
   geos_BufferParamsSetMitreLimit :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CDouble -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferParams_setQuadrantSegments_r"
-  geos_BufferParamsSetQuadrantSegments :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CInt -> IO CInt 
+  geos_BufferParamsSetQuadrantSegments :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CInt -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferParams_setSingleSided_r"
   geos_BufferParamsSetSingleSided :: GEOSContextHandle_t -> Ptr GEOSBufferParams -> CInt -> IO CInt
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferWithParams_r"
   geos_BufferWithParams :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSBufferParams -> CDouble -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBufferWithStyle_r"
   geos_BufferWithStyle :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CDouble -> CInt -> CInt -> CInt -> CDouble -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSOffsetCurve_r"
   geos_OffsetCurve :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CDouble -> CInt -> CInt -> CDouble -> IO (Ptr GEOSGeometry)
 
 -----------
 --- Topology
 ----------
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSEnvelope_r"
-  geos_Envelope :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry) 
-  
-foreign import ccall 
+  geos_Envelope :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
+
+foreign import ccall
   "geos_c.h GEOSIntersection_r"
   geos_Intersection :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSConvexHull_r"
   geos_ConvexHull :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSDifference_r"
   geos_Difference :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSSymDifference_r"
   geos_SymDifference :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSBoundary_r"
   geos_Boundary :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSUnion_r"
   geos_Union :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSUnaryUnion_r"
   geos_UnaryUnion :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSGetCentroid_r"
   geos_GetCentroid :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPointOnSurface_r"
   geos_PointsOnSurface :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSNode_r"
   geos_Node :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSGeometry)
 
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSDelaunayTriangulation_r"
   geos_DelaunayTriangulation :: GEOSContextHandle_t -> Ptr GEOSGeometry -> CDouble -> CInt -> IO (Ptr GEOSGeometry)
 
 
 #if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR > 4
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSVoronoiDiagram_r"
   geos_VoronoiDiagram :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> CDouble -> CInt -> IO (Ptr GEOSGeometry)
 #endif
@@ -369,96 +369,96 @@ foreign import ccall
 --Binary Predicates.
 -----
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSDisjoint_r"
   geos_Disjoint :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSTouches_r"
   geos_Touches :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCrosses_r"
   geos_Crosses :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
-  
-foreign import ccall 
+
+foreign import ccall
   "geos_c.h GEOSIntersects_r"
   geos_Intersects :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWithin_r"
   geos_Within :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSContains_r"
   geos_Contains :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSOverlaps_r"
   geos_Overlaps :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSEquals_r"
   geos_Equals :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSEqualsExact_r"
   geos_EqualsExact :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> CDouble -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCovers_r"
   geos_Covers :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSCoveredBy_r"
   geos_CoveredBy :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO CChar
 
 --- prepared Geometries
 
 ---  Readers / Writers
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKBReader_create_r"
-  geos_WKBReaderCreate :: GEOSContextHandle_t -> IO (Ptr GEOSWKBReader) 
+  geos_WKBReaderCreate :: GEOSContextHandle_t -> IO (Ptr GEOSWKBReader)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &GEOSWKBReader_destroy_r"
   geos_WKBReaderDestroy :: FunPtr (GEOSContextHandle_t -> Ptr GEOSWKBReader -> IO ())
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKBReader_read_r"
   geos_WKBReaderRead :: GEOSContextHandle_t -> Ptr GEOSWKBReader -> CString  -> CSize -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKBReader_readHEX_r"
   geos_WKBReaderReadHex :: GEOSContextHandle_t -> Ptr GEOSWKBReader -> CString -> CSize -> IO (Ptr GEOSGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKBWriter_create_r"
-  geos_WKBWriterCreate :: GEOSContextHandle_t -> IO (Ptr GEOSWKBWriter) 
+  geos_WKBWriterCreate :: GEOSContextHandle_t -> IO (Ptr GEOSWKBWriter)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &GEOSWKBWriter_destroy_r"
   geos_WKBWriterDestroy :: FunPtr ( GEOSContextHandle_t -> Ptr GEOSWKBWriter -> IO ())
 
   -- caller owns results
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKBWriter_write_r"
   geos_WKBWriterWrite :: GEOSContextHandle_t -> Ptr GEOSWKBWriter -> Ptr GEOSGeometry -> Ptr CSize -> IO CString
 
   -- caller owns results
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKBWriter_writeHEX_r"
   geos_WKBWriterWriteHex :: GEOSContextHandle_t -> Ptr GEOSWKBWriter -> Ptr GEOSGeometry -> Ptr CSize -> IO CString
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKBWriter_setIncludeSRID_r"
   geos_WKBWriterSetIncludeSRID :: GEOSContextHandle_t -> Ptr GEOSWKBWriter -> CChar -> IO ()
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSWKTReader_create_r"
-  geos_WKTReaderCreate :: GEOSContextHandle_t -> IO (Ptr GEOSWKTReader) 
+  geos_WKTReaderCreate :: GEOSContextHandle_t -> IO (Ptr GEOSWKTReader)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &GEOSWKTReader_destroy_r"
   geos_WKTReaderDestroy :: FunPtr (GEOSContextHandle_t -> Ptr GEOSWKTReader -> IO ())
 
@@ -483,110 +483,109 @@ foreign import ccall
 --TODO: 1085 finish writer methods
 
 -- following return 0 on exception, 1 otherwise
-foreign import ccall  
+foreign import ccall
   "geos_c.h GEOSArea_r"
-  geos_Area :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt 
+  geos_Area :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt
 
-foreign import ccall  
+foreign import ccall
   "geos_c.h GEOSLength_r"
-  geos_Length :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt 
+  geos_Length :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt
 
-foreign import ccall  
+foreign import ccall
   "geos_c.h GEOSDistance_r"
-  geos_Distance :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt 
+  geos_Distance :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt
 
-foreign import ccall  
+foreign import ccall
   "geos_c.h GEOSHausdorffDistance_r"
-  geos_HausdorffDistance :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt 
+  geos_HausdorffDistance :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt
 
-foreign import ccall  
+foreign import ccall
   "geos_c.h GEOSHausdorffDistanceDensify_r"
-  geos_HausdorffDistanceDensify :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> CDouble -> Ptr CDouble -> IO CInt 
+  geos_HausdorffDistanceDensify :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> CDouble -> Ptr CDouble -> IO CInt
 
-foreign import ccall  
+foreign import ccall
   "geos_c.h GEOSGeomGetLength_r"
-  geos_GeomGetLength :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt 
+  geos_GeomGetLength :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr CDouble -> IO CInt
 
-foreign import ccall  
+foreign import ccall
   "geos_c.h GEOSNearestPoints_r"
   geos_NearestPoints :: GEOSContextHandle_t -> Ptr GEOSGeometry -> Ptr GEOSGeometry -> IO (Ptr GEOSCoordSequence)
 
 -- | Prepared Geometries
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPrepare_r"
   geos_Prepare :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO (Ptr GEOSPreparedGeometry)
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &GEOSPreparedGeom_destroy_r"
   geos_PreparedGeomDestroy :: FunPtr (GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> IO ())
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedContains_r"
   geos_PreparedContains :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedContainsProperly_r"
   geos_PreparedContainsProperly :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedCoveredBy_r"
   geos_PreparedCoveredBy :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedCovers_r"
   geos_PreparedCovers :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedCrosses_r"
   geos_PreparedCrosses :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedDisjoint_r"
   geos_PreparedDisjoint :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedIntersects_r"
   geos_PreparedIntersects :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedOverlaps_r"
   geos_PreparedOverlaps :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedTouches_r"
   geos_PreparedTouches :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSPreparedWithin_r"
   geos_PreparedWithin :: GEOSContextHandle_t -> Ptr GEOSPreparedGeometry -> Ptr GEOSGeometry -> IO CChar
 
 -- STRTREE
 
 #if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR > 4
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSSTRtree_create_r"
   geos_STRTreeCreate :: GEOSContextHandle_t -> CSize -> IO (Ptr GEOSSTRTree)
 
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSSTRtree_insert_r"
   geos_STRTreeInsert :: GEOSContextHandle_t -> Ptr GEOSSTRTree -> Ptr GEOSGeometry -> Ptr () -> IO ()
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSSTRtree_query_r"
   geos_STRTreeQuery :: GEOSContextHandle_t -> Ptr GEOSSTRTree -> Ptr GEOSGeometry -> GEOSQueryCallback -> Ptr () -> IO ()
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSSTRtree_iterate_r"
   geos_STRTreeIterate :: GEOSContextHandle_t -> Ptr GEOSSTRTree -> GEOSQueryCallback -> Ptr () -> IO ()
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h &GEOSSTRtree_destroy_r"
   geos_STRTreeDestroy :: FunPtr (GEOSContextHandle_t -> Ptr GEOSSTRTree -> IO ())
 
 #endif
 
-foreign import ccall 
+foreign import ccall
   "geos_c.h GEOSisValid_r"
   geos_isValid :: GEOSContextHandle_t -> Ptr GEOSGeometry -> IO CChar
-

--- a/tests/ParsingSpec.hs
+++ b/tests/ParsingSpec.hs
@@ -14,6 +14,7 @@ import qualified Data.Geometry.Geos.Raw.CoordSeq as RC
 import qualified Data.Geometry.Geos.Raw.Serialize as RS
 import qualified Data.Geometry.Geos.Raw.Geometry as R
 import qualified Data.Vector as V
+import Data.Maybe (fromJust)
 
 import SpecSampleData
 
@@ -50,6 +51,23 @@ parsingSpecs = describe "Tests Serialization" $ do
   it "handles nonesense properly" $ do
     let bs = "2D50491A5DC024275C1ED5DE4040" :: BS.ByteString
     Nothing `shouldBe` (fmap ensurePoint $ readHex bs)
+
+  it "can write/read with zero loss of information" $ do
+    let bs = "0105000020C46E000001000000010200000004000000EE2DE25E859A20410829F224364B5A41BD757FB6679A204115C6D8E9304B5A4177111862469A2041A03F04E32C4B5A41BC1D3ADD459A2041793C8CD92C4B5A41" :: BS.ByteString
+        srid = Just 28356
+        points = [[(544066.685319362, 6892760.57728029),
+                   (544051.856441192, 6892739.65385582),
+                   (544035.191589876, 6892723.54713431),
+                   (544034.932084016, 6892723.39918434)]]
+        expectedGeo = MultiLineStringGeometry (makeMultiLineString points) srid
+        parsedGeo = fromJust (fmap ensureMultiLineString $ readHex bs)
+    parsedGeo `shouldBe` expectedGeo
+    let encodedHex = writeHex expectedGeo
+    encodedHex `shouldBe` bs
+
+
+
+
 
 searchPoints :: [Geometry Point] -> Geometry Polygon -> [Geometry Point]
 searchPoints points polygon = filter f points


### PR DESCRIPTION
It seems that something goes awry with this particular WKB string... it should be a simple MultiLineString with 4 points, and it can be read correctly - but when writing it back to Hex it somehow gets converted back into a MultiPoint

Note the single digit difference from 0105.... to 0104.... in the following test output.

![image](https://user-images.githubusercontent.com/151124/30165507-9e1f9f48-9423-11e7-9a76-2d04de07e111.png)

I have traced this through this library but can't see anywhere that it would be flipping these geometry types. Not really sure how to tell if this is an upstream problem or not.
