### PR TITLE
Fixes #35 - export constructors for geometry data types

### DIFF
--- a/src/Data/Geometry/Geos/Geometry.hs
+++ b/src/Data/Geometry/Geos/Geometry.hs
@@ -9,24 +9,25 @@
 module Data.Geometry.Geos.Geometry
   ( Geometry(..)
   , GeometryConstructionError
-  , Point
+  , Point(..)
   , point
-  , LinearRing
+  , LinearRing(..)
   , linearRing
-  , LineString
+  , LineString(..)
   , lineString
-  , Polygon
+  , Polygon(..)
   , polygon
-  , MultiPoint
+  , MultiPoint(..)
   , multiPoint
-  , MultiLineString
+  , MultiLineString(..)
   , multiLineString
-  , MultiPolygon
+  , MultiPolygon(..)
   , multiPolygon
   , GeometryCollection
   , geometryCollection
   , Some(..)
-  , Coordinate
+  , Coordinate(..)
+  , CoordinateSequence
   , coordinate2
   , coordinate3
   , SRID


### PR DESCRIPTION
As discussed in #35, I exported the data constructors so we can easily access the underlying data.

To retrieve the coordinates of a point as double as requested in #36, we could do something like:

``` haskell
pointToDoubleArray :: Geo Point -> [Double]
pointToDoubleArray (GeoPoint (Point (Coordinate2 x y))) = [x,y]
pointToDoubleArray (GeoPoint (Point (Coordinate3 x y z))) = [x,y,z]
```

However, I am a little confused about the current geos.cabal. The latest version mentioned there is 0.4.0 whereas the newest version on Hackage is 0.4.1. Is there a specific reason why the latest cabal file was not committed?

